### PR TITLE
ssp geniee bidder user sync code updated

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -16,6 +16,7 @@ import { config } from "../src/config.js";
 const BIDDER_CODE = "ssp_geniee";
 export const BANNER_ENDPOINT =
   "https://aladdin.genieesspv.jp/yie/ld/api/ad_call/v2";
+export const USER_SYNC_ENDPOINT = 'https://cs.gssprt.jp/yie/ld/mcs';
 // export const ENDPOINT_USERSYNC = '';
 const SUPPORTED_MEDIA_TYPES = [BANNER];
 const DEFAULT_CURRENCY = "JPY";
@@ -475,19 +476,47 @@ export const spec = {
     }
     return bidResponses;
   },
-  getUserSyncs: function (syncOptions, serverResponses) {
-    const syncs = [];
-
-    // if we need user sync, we add this part after preparing the endpoint
-    /* if (syncOptions.pixelEnabled) {
-      syncs.push({
-        type: 'image',
-        url: ENDPOINT_USERSYNC
+    /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+    getUserSyncs: function (syncOptions, serverResponses) {
+      const syncs = [];
+      if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
+        return syncs;
+      }
+  
+      serverResponses.forEach((serverResponse) => {
+        if (!serverResponse || !serverResponse.body) {
+          return;
+        }
+  
+        const values = Object.values(serverResponse.body);
+        if (!values.length || !values[0]) {
+          return;
+        }
+  
+        const bid = values[0];
+        const decodedAdm = decodeURIComponent(bid.adm)
+        // admの中にはhttps:\/\/cs.gssprt.jp\/yie\/ld\/mcs?ver=1&dspid=lamp&format=gif&vid=1\"のような文字列があるので、ここからクエリを抜き出す
+        const reg = new RegExp('https:\\\\/\\\\/cs.gssprt.jp\\\\/yie\\\\/ld\\\\/mcs\\?([^\\\\"]+)\\\\"', 'g');
+        const csQuery = Array.from(decodedAdm.matchAll(reg), (match) => match[1]);
+        if (!csQuery.length) {
+          return;
+        }
+  
+        csQuery.forEach((query) => {
+          syncs.push({
+            type: syncOptions.pixelEnabled ? 'image' : 'iframe',
+            url: USER_SYNC_ENDPOINT + '?' + query
+          });
+        });
       });
-    } */
-
-    return syncs;
-  },
+      return syncs;
+    },
   onTimeout: function (timeoutData) {},
   onBidWon: function (bid) {},
   onSetTargeting: function (bid) {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [ ] Checked bidder is compatible with the current prebid version
- [ ] Checked all the relvant dependencies
- [ ] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
