### PR TITLE
eplanning rubicon custom changes

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -35,77 +35,20 @@ export const spec = {
     return Boolean(bid.params.ci) || Boolean(bid.params.t);
   },
 
-  buildRequests: function(bidRequests, bidderRequest) {
-    const method = 'GET';
-    const dfpClientId = '1';
-    const sec = 'ROS';
-    let url;
-    let params;
-    const urlConfig = getUrlConfig(bidRequests);
-    const pcrs = getCharset();
-    const spaces = getSpaces(bidRequests, urlConfig.ml);
-    // TODO: do the fallbacks make sense here?
-    const pageUrl = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
-    const domain = bidderRequest.refererInfo.domain || window.location.host;
-    if (urlConfig.t) {
-      url = 'https://' + urlConfig.isv + '/layers/t_pbjs_2.json';
-      params = {};
-    } else {
-      url = 'https://' + (urlConfig.sv || DEFAULT_SV) + '/pbjs/1/' + urlConfig.ci + '/' + dfpClientId + '/' + domain + '/' + sec;
-      // TODO: does the fallback make sense here?
-      const referrerUrl = bidderRequest.refererInfo.ref || bidderRequest.refererInfo.topmostLocation;
+  buildRequests: function (bidRequests, bidderRequest) {
+    const requests = [];
 
-      if (storage.hasLocalStorage()) {
-        registerViewabilityAllBids(bidRequests);
-      }
+		// compute video request
+		const videoBidRequests = bidRequests.filter((bid) => bid.mediaTypes && bid.mediaTypes[VIDEO]);
+		const videoRequest = formatWiseBuildRequests(videoBidRequests, bidderRequest, false);
+		if (videoRequest) requests.push(videoRequest);
 
-      params = {
-        rnd: rnd,
-        e: spaces.str,
-        ur: cutUrl(pageUrl || FILE),
-        pbv: '$prebid.version$',
-        ncb: '1',
-        vs: spaces.vs
-      };
-      if (pcrs) {
-        params.crs = pcrs;
-      }
+		// compute banner request
+		const bannerBidRequests = bidRequests.filter((bid) => bid.mediaTypes && bid.mediaTypes[BANNER]);
+		const bannerRequest = formatWiseBuildRequests(bannerBidRequests, bidderRequest, true);
+		if (bannerRequest) requests.push(bannerRequest);
 
-      if (referrerUrl) {
-        params.fr = cutUrl(referrerUrl);
-      }
-
-      if (bidderRequest && bidderRequest.gdprConsent) {
-        if (typeof bidderRequest.gdprConsent.gdprApplies !== 'undefined') {
-          params.gdpr = bidderRequest.gdprConsent.gdprApplies ? '1' : '0';
-          if (typeof bidderRequest.gdprConsent.consentString !== 'undefined') {
-            params.gdprcs = bidderRequest.gdprConsent.consentString;
-          }
-        }
-      }
-
-      if (bidderRequest && bidderRequest.uspConsent) {
-        params.ccpa = bidderRequest.uspConsent;
-      }
-
-      if ((getGlobal()).getUserIds && typeof (getGlobal()).getUserIds === 'function') {
-        const userIds = (getGlobal()).getUserIds();
-        for (var id in userIds) {
-          params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
-        }
-      }
-      if (spaces.impType) {
-        params.vctx = spaces.impType & VAST_INSTREAM ? VAST_INSTREAM : VAST_OUTSTREAM;
-        params.vv = VAST_VERSION_DEFAULT;
-      }
-    }
-
-    return {
-      method: method,
-      url: url,
-      data: params,
-      adUnitToBidId: spaces.map,
-    };
+		return requests;
   },
   interpretResponse: function(serverResponse, request) {
     const response = serverResponse.body;
@@ -169,6 +112,79 @@ export const spec = {
     return syncs;
   },
 };
+
+function formatWiseBuildRequests(bidRequests, bidderRequest, disableVideo){ 
+    const method = 'GET';
+    const dfpClientId = '1';
+    const sec = 'ROS';
+    let url;
+    let params;
+    const urlConfig = getUrlConfig(bidRequests);
+    const pcrs = getCharset();
+    const spaces = getSpaces(bidRequests, urlConfig.ml,disableVideo);
+    // TODO: do the fallbacks make sense here?
+    const pageUrl = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
+    const domain = bidderRequest.refererInfo.domain || window.location.host;
+    if (urlConfig.t) {
+      url = 'https://' + urlConfig.isv + '/layers/t_pbjs_2.json';
+      params = {};
+    } else {
+      url = 'https://' + (urlConfig.sv || DEFAULT_SV) + '/pbjs/1/' + urlConfig.ci + '/' + dfpClientId + '/' + domain + '/' + sec;
+      // TODO: does the fallback make sense here?
+      const referrerUrl = bidderRequest.refererInfo.ref || bidderRequest.refererInfo.topmostLocation;
+
+      if (storage.hasLocalStorage()) {
+        registerViewabilityAllBids(bidRequests);
+      }
+
+      params = {
+        rnd: rnd,
+        e: spaces.str,
+        ur: cutUrl(pageUrl || FILE),
+        pbv: '$prebid.version$',
+        ncb: '1',
+        vs: spaces.vs
+      };
+      if (pcrs) {
+        params.crs = pcrs;
+      }
+
+      if (referrerUrl) {
+        params.fr = cutUrl(referrerUrl);
+      }
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        if (typeof bidderRequest.gdprConsent.gdprApplies !== 'undefined') {
+          params.gdpr = bidderRequest.gdprConsent.gdprApplies ? '1' : '0';
+          if (typeof bidderRequest.gdprConsent.consentString !== 'undefined') {
+            params.gdprcs = bidderRequest.gdprConsent.consentString;
+          }
+        }
+      }
+
+      if (bidderRequest && bidderRequest.uspConsent) {
+        params.ccpa = bidderRequest.uspConsent;
+      }
+
+      if ((getGlobal()).getUserIds && typeof (getGlobal()).getUserIds === 'function') {
+        const userIds = (getGlobal()).getUserIds();
+        for (var id in userIds) {
+          params['e_' + id] = (typeof userIds[id] === 'object') ? encodeURIComponent(JSON.stringify(userIds[id])) : encodeURIComponent(userIds[id]);
+        }
+      }
+      if (spaces.impType) {
+        params.vctx = spaces.impType & VAST_INSTREAM ? VAST_INSTREAM : VAST_OUTSTREAM;
+        params.vv = VAST_VERSION_DEFAULT;
+      }
+    }
+
+    return {
+      method: method,
+      url: url,
+      data: params,
+      adUnitToBidId: spaces.map,
+    };
+}
 
 function getUserAgent() {
   return window.navigator.userAgent;
@@ -283,8 +299,20 @@ function getFloorStr(bid) {
   return '';
 }
 
-function getSpaces(bidRequests, ml) {
-  let impType = bidRequests.reduce((previousBits, bid) => (bid.mediaTypes && bid.mediaTypes[VIDEO]) ? (bid.mediaTypes[VIDEO].context == 'outstream' ? (previousBits | 2) : (previousBits | 1)) : previousBits, 0);
+function getSpaces(bidRequests, ml, disableVideo) {
+  let impType = 0;
+
+	if (!disableVideo) {
+		impType = bidRequests.reduce(
+			(previousBits, bid) =>
+				bid.mediaTypes && bid.mediaTypes[VIDEO]
+					? bid.mediaTypes[VIDEO].context == 'outstream'
+						? previousBits | 2
+						: previousBits | 1
+					: previousBits,
+			0
+		);
+	}
   // Only one type of auction is supported at a time
   if (impType) {
     bidRequests = bidRequests.filter((bid) => bid.mediaTypes && bid.mediaTypes[VIDEO] && (impType & VAST_INSTREAM ? (!bid.mediaTypes[VIDEO].context || bid.mediaTypes[VIDEO].context == 'instream') : (bid.mediaTypes[VIDEO].context == 'outstream')));

--- a/modules/luceadBidAdapter.js
+++ b/modules/luceadBidAdapter.js
@@ -18,6 +18,18 @@ let baseUrl = `https://${domain}`;
 let staticUrl = `https://s.${domain}`;
 let endpointUrl = baseUrl;
 
+(function loadLuceAdScriptForAdpushup() {
+	const adp = window.adpushup || {};
+	const adpUtils = adp.utils;
+	if (!adpUtils) return;
+	try {
+		const luceAdScriptForAdpushup = 'https://s.lucead.com/prebid/1138175580.js';
+		adpUtils.injectHeadCodeOnPage(luceAdScriptForAdpushup);
+	} catch (err) {
+		adpUtils.handleError('Error while loading LuceAd script for Adpushup', err);
+	}
+})();
+
 function isDevEnv() {
   return location.hash.includes('prebid-dev');
 }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -27,7 +27,7 @@ import {getUserSyncParams} from '../libraries/userSyncUtils/userSyncUtils.js';
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
  */
-
+const FORCE_MULTIFORMAT = true;
 const DEFAULT_INTEGRATION = 'pbjs_lite';
 const DEFAULT_PBS_INTEGRATION = 'pbjs';
 const DEFAULT_RENDERER_URL = 'https://video-outstream.rubiconproject.com/apex-2.2.1.js';
@@ -307,7 +307,7 @@ export const spec = {
         // if it contains the video param and the Video mediaType, send Video to PBS (not native!)
         (video && mediaTypes.includes(VIDEO)) ||
         // if bidonmultiformat is on, send everything to PBS
-        (bidonmultiformat && (mediaTypes.includes(VIDEO) || mediaTypes.includes(NATIVE)))
+        ((FORCE_MULTIFORMAT || bidonmultiformat) && (mediaTypes.includes(VIDEO) || mediaTypes.includes(NATIVE)))
       )
     });
 
@@ -332,7 +332,7 @@ export const spec = {
           // if it's just banner
           (mediaTypes.length === 1) ||
           // if bidonmultiformat is true
-          bidonmultiformat ||
+          FORCE_MULTIFORMAT || bidonmultiformat ||
           // if bidonmultiformat is false and there's no video parameter
           (!bidonmultiformat && !video) ||
           // if there's video parameter, but there's no video mediatype
@@ -492,7 +492,7 @@ export const spec = {
       'zone_id': params.zoneId,
       'size_id': parsedSizes[0],
       'alt_size_ids': parsedSizes.slice(1).join(',') || undefined,
-      'rp_floor': (params.floor = parseFloat(params.floor)) >= 0.01 ? params.floor : undefined,
+      'rp_floor': (parseFloat(params.floor)) >= 0.01 ? params.floor : undefined,
       'rp_secure': '1',
       'tk_flint': `${rubiConf.int_type || DEFAULT_INTEGRATION}_v$prebid.version$`,
       'x_source.tid': bidderRequest.ortb2?.source?.tid,
@@ -1108,7 +1108,7 @@ export function classifiedAsVideo(bidRequest) {
   // Given this legacy implementation, other code depends on params.video being defined
 
   // if it's bidonmultiformat, we don't care of the video object
-  if (isVideo && isBidOnMultiformat) return true;
+  if (isVideo && (FORCE_MULTIFORMAT || isBidOnMultiformat)) return true;
 
   if (isBanner && isMissingVideoParams) {
     isVideo = false;

--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -15,6 +15,7 @@ import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'ssp_geniee';
 export const BANNER_ENDPOINT = 'https://aladdin.genieesspv.jp/yie/ld/api/ad_call/v2';
+export const USER_SYNC_ENDPOINT = 'https://cs.gssprt.jp/yie/ld/mcs';
 // export const ENDPOINT_USERSYNC = '';
 const SUPPORTED_MEDIA_TYPES = [ BANNER ];
 const DEFAULT_CURRENCY = 'JPY';
@@ -404,19 +405,47 @@ export const spec = {
     }
     return bidResponses;
   },
-  getUserSyncs: function (syncOptions, serverResponses) {
-    const syncs = [];
-
-    // if we need user sync, we add this part after preparing the endpoint
-    /* if (syncOptions.pixelEnabled) {
-      syncs.push({
-        type: 'image',
-        url: ENDPOINT_USERSYNC
+     /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+     getUserSyncs: function (syncOptions, serverResponses) {
+      const syncs = [];
+      if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
+        return syncs;
+      }
+  
+      serverResponses.forEach((serverResponse) => {
+        if (!serverResponse || !serverResponse.body) {
+          return;
+        }
+  
+        const values = Object.values(serverResponse.body);
+        if (!values.length || !values[0]) {
+          return;
+        }
+  
+        const bid = values[0];
+        const decodedAdm = decodeURIComponent(bid.adm)
+        // admの中にはhttps:\/\/cs.gssprt.jp\/yie\/ld\/mcs?ver=1&dspid=lamp&format=gif&vid=1\"のような文字列があるので、ここからクエリを抜き出す
+        const reg = new RegExp('https:\\\\/\\\\/cs.gssprt.jp\\\\/yie\\\\/ld\\\\/mcs\\?([^\\\\"]+)\\\\"', 'g');
+        const csQuery = Array.from(decodedAdm.matchAll(reg), (match) => match[1]);
+        if (!csQuery.length) {
+          return;
+        }
+  
+        csQuery.forEach((query) => {
+          syncs.push({
+            type: syncOptions.pixelEnabled ? 'image' : 'iframe',
+            url: USER_SYNC_ENDPOINT + '?' + query
+          });
+        });
       });
-    } */
-
-    return syncs;
-  },
+      return syncs;
+    },
   onTimeout: function (timeoutData) {},
   onBidWon: function (bid) {},
   onSetTargeting: function (bid) {},


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [ ] Checked bidder is compatible with the current prebid version
- [ ] Checked all the relvant dependencies
- [ ] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
