### PR TITLE
code for gpid gpt dependency removed

### DIFF
--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -1,47 +1,63 @@
 import {
   deepAccess,
-  isAdUnitCodeMatchingSlot,
-  isGptPubadsDefined,
   logInfo,
   pick,
   deepSetValue
 } from '../src/utils.js';
 import {config} from '../src/config.js';
 import {getHook} from '../src/hook.js';
-import {find} from '../src/polyfill.js';
 
 const MODULE_NAME = 'GPT Pre-Auction';
 export let _currentConfig = {};
 let hooksAdded = false;
 
-export const appendGptSlots = adUnits => {
-  const { customGptSlotMatching } = _currentConfig;
+window.adpushup = window.adpushup || {};
+const adp = window.adpushup;
+const adpConfig = adp.config || {};
 
-  if (!isGptPubadsDefined()) {
-    return;
+window.adpTags = window.adpTags || {};
+const adpTags = window.adpTags;
+const adpSlots = adpTags.adpSlots || {};
+
+const getAdUnitPath = function(code) {
+  const adpSlot = adpSlots[code];
+  if (!adpSlot) return null;
+  const {childPublisherId,isMcmEnabled=false } = adpConfig.mcm;
+
+  let dfpNetwork = adpSlot.activeDFPNetwork;
+  if (isMcmEnabled) {
+    dfpNetwork += `,${childPublisherId}`;
   }
+  const dfpAdUnitCode = adpSlot.currentGptSlotData && adpSlot.currentGptSlotData.dfpAdunitCode;
+  return `/${dfpNetwork}/${dfpAdUnitCode}`;
+}
 
+export const appendGptSlots = adUnits => {
+  if (!adpSlots) {
+    return; 
+  }
   const adUnitMap = adUnits.reduce((acc, adUnit) => {
     acc[adUnit.code] = acc[adUnit.code] || [];
     acc[adUnit.code].push(adUnit);
     return acc;
   }, {});
 
-  window.googletag.pubads().getSlots().forEach(slot => {
-    const matchingAdUnitCode = find(Object.keys(adUnitMap), customGptSlotMatching
-      ? customGptSlotMatching(slot)
-      : isAdUnitCodeMatchingSlot(slot));
-
+  for (adUnit in adpSlots) {
+    const matchingAdUnitCode = Object.keys(adUnitMap).find((key) => key === adUnit);
     if (matchingAdUnitCode) {
       const adserver = {
-        name: 'gam',
-        adslot: sanitizeSlotPath(slot.getAdUnitPath())
+        name: "gam",
+        adslot: sanitizeSlotPath(getAdUnitPath(adUnit)),
       };
       adUnitMap[matchingAdUnitCode].forEach((adUnit) => {
-        deepSetValue(adUnit, 'ortb2Imp.ext.data.adserver', Object.assign({}, adUnit.ortb2Imp?.ext?.data?.adserver, adserver));
+        deepSetValue(
+          adUnit,
+          "ortb2Imp.ext.data.adserver",
+          Object.assign({}, adUnit.ortb2Imp?.ext?.data?.adserver, adserver)
+        );
       });
     }
-  });
+  }
 };
 
 const sanitizeSlotPath = (path) => {
@@ -62,13 +78,11 @@ const defaultPreAuction = (adUnit, adServerAdSlot) => {
     return context.pbadslot;
   }
 
-  // confirm that GPT is set up
-  if (!isGptPubadsDefined()) {
-    return;
+  if (!adpSlots) {
+    return 
   }
-
   // find all GPT slots with this name
-  var gptSlots = window.googletag.pubads().getSlots().filter(slot => slot.getAdUnitPath() === adServerAdSlot);
+  var gptSlots = Object.keys(adpSlots).filter(slot => getAdUnitPath(slot) === adServerAdSlot);
 
   if (gptSlots.length === 0) {
     return; // should never happen


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [ ] Checked bidder is compatible with the current prebid version
- [ ] Checked all the relvant dependencies
- [ ] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
