### PR TITLE
Add relevatehealth bidder

### DIFF
--- a/modules/relevatehealthBidAdapter.js
+++ b/modules/relevatehealthBidAdapter.js
@@ -1,144 +1,27 @@
-import { formatResponse } from '../libraries/deepintentUtils/index.js';
-import {
-  registerBidder
-} from '../src/adapters/bidderFactory.js';
-import {
-  BANNER
-} from '../src/mediaTypes.js';
-import {
-  deepAccess,
-  generateUUID,
-  isArray,
-  logError
-} from '../src/utils.js';
-const BIDDER_CODE = 'relevatehealth';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { getBannerRequest, getBannerResponse } from '../libraries/audUtils/bidderUtils.js';
+
+const BCODE = 'relevatehealth';
 const ENDPOINT_URL = 'https://rtb.relevate.health/prebid/relevate';
 
-function buildRequests(bidRequests, bidderRequest) {
-  const requests = [];
-  // Loop through each bid request
-  bidRequests.forEach(bid => {
-    // Construct the bid request object
-    const request = {
-      id: generateUUID(),
-      placementId: bid.params.placement_id,
-      imp: [{
-        id: bid.bidId,
-        banner: getBanner(bid),
-        bidfloor: getFloor(bid)
-      }],
-      site: getSite(bidderRequest),
-      user: buildUser(bid)
-    };
-    // Get uspConsent from bidderRequest
-    if (bidderRequest && bidderRequest.uspConsent) {
-      request.us_privacy = bidderRequest.uspConsent;
-    }
-    // Get GPP Consent from bidderRequest
-    if (bidderRequest?.gppConsent?.gppString) {
-      request.gpp = bidderRequest.gppConsent.gppString;
-      request.gpp_sid = bidderRequest.gppConsent.applicableSections;
-    } else if (bidderRequest?.ortb2?.regs?.gpp) {
-      request.gpp = bidderRequest.ortb2.regs.gpp;
-      request.gpp_sid = bidderRequest.ortb2.regs.gpp_sid;
-    }
-    // Get coppa compliance from bidderRequest
-    if (bidderRequest?.ortb2?.regs?.coppa) {
-      request.coppa = 1;
-    }
-    // Push the constructed bid request to the requests array
-    requests.push(request);
-  });
-  // Return the array of bid requests
-  return {
-    method: 'POST',
-    url: ENDPOINT_URL,
-    data: JSON.stringify(requests),
-    options: {
-      contentType: 'application/json',
-    }
-  };
-}
-// Format the response as per the standards
-function interpretResponse(bidResponse, bidRequest) {
-  let resp = [];
-  if (bidResponse && bidResponse.body) {
-    try {
-      let bids = bidResponse.body.seatbid && bidResponse.body.seatbid[0] ? bidResponse.body.seatbid[0].bid : [];
-      if (bids) {
-        bids.forEach(bidObj => {
-          let newBid = formatResponse(bidObj);
-          newBid.mediaType = BANNER;
-          resp.push(newBid);
-        });
-      }
-    } catch (err) {
-      logError(err);
-    }
-  }
-  return resp;
-}
-// Function to check if Bid is valid
-function isBidRequestValid(bid) {
-  return !!(bid.params.placement_id && bid.params.user_id);
-}
-// Function to get banner details
-function getBanner(bid) {
-  if (deepAccess(bid, 'mediaTypes.banner')) {
-    // Fetch width and height from MediaTypes object, if not provided in bid params
-    if (deepAccess(bid, 'mediaTypes.banner.sizes') && !bid.params.height && !bid.params.width) {
-      let sizes = deepAccess(bid, 'mediaTypes.banner.sizes');
-      if (isArray(sizes) && sizes.length > 0) {
-        return {
-          h: sizes[0][1],
-          w: sizes[0][0]
-        };
-      }
-    } else {
-      return {
-        h: bid.params.height,
-        w: bid.params.width
-      };
-    }
-  }
-}
-// Function to get bid_floor
-function getFloor(bid) {
-  if (bid.params && bid.params.bid_floor) {
-    return bid.params.bid_floor;
-  } else {
-    return 0;
-  }
-}
-// Function to get site details
-function getSite(bidderRequest) {
-  let site = {};
-  if (bidderRequest && bidderRequest.refererInfo && bidderRequest.refererInfo.page) {
-    site.name = bidderRequest.refererInfo.domain;
-  } else {
-    site.name = '';
-  }
-  return site;
-}
-// Function to build the user object
-function buildUser(bid) {
-  if (bid && bid.params) {
-    return {
-      id: bid.params.user_id && typeof bid.params.user_id == 'string' ? bid.params.user_id : '',
-      // TODO: commented out because of rule violations
-      buyeruid: '', // localStorage.getItem('adx_profile_guid') ? localStorage.getItem('adx_profile_guid') : '',
-      keywords: bid.params.keywords && typeof bid.params.keywords == 'string' ? bid.params.keywords : '',
-      customdata: bid.params.customdata && typeof bid.params.customdata == 'string' ? bid.params.customdata : ''
-    };
-  }
-}
-// Export const spec
 export const spec = {
-  code: BIDDER_CODE,
-  supportedMediaTypes: BANNER,
-  isBidRequestValid,
-  buildRequests,
-  interpretResponse
-}
+	code: BCODE,
+	supportedMediaTypes: BANNER,
+	// Determines whether given bid request is valid or not
+	isBidRequestValid: (bidReqParam) => {
+		return !!bidReqParam.params.placement_id;
+	},
+	// Make a server request from the list of BidRequests
+	buildRequests: (bidReq, serverReq) => {
+		// Get Requests based on media types
+		return getBannerRequest(bidReq, serverReq, ENDPOINT_URL);
+	},
+	// Unpack the response from the server into a list of bids.
+	interpretResponse: (bidResp, bidReq) => {
+		const Response = getBannerResponse(bidResp, BANNER);
+		return Response;
+	}
+};
 
 registerBidder(spec);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [ ] Checked bidder is compatible with the current prebid version
- [ ] Checked all the relvant dependencies
- [ ] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
