### PR TITLE
Add 'revnew' as an alias in nexx360 adapter and update version to 9.41.1

### DIFF
--- a/modules/nexx360BidAdapter.js
+++ b/modules/nexx360BidAdapter.js
@@ -35,7 +35,8 @@ const ALIASES = [
   { code: 'pubtech' },
   { code: '1accord', gvlid: 965 },
   { code: 'easybid', gvlid: 1068 },
-  { code: 'prismassp', gvlid: 965 }
+  { code: 'prismassp', gvlid: 965 },
+  { code: 'revnew', gvlid: 1468 }
 ];
 
 export const storage = getStorageManager({


### PR DESCRIPTION
## Summary
Adds revnew bidder support by registering it as an alias of nexx360BidAdapter.

## Changes
- Added `{ code: 'revnew', gvlid: 1468 }` to the ALIASES array in nexx360BidAdapter.js

## Why
Revnew uses the nexx360 infrastructure, so it doesn't need a separate adapter. This was added to the official Prebid.js repo in v10.9.0 (PR #13808).

## Testing
- Confirm bid requests to revnew route through nexx360 endpoint (`https://fast.nexx360.io/booster`)

## Params
Publishers can use either `tagId` or `placement` (mutually exclusive):
```js
{
  bidder: 'revnew',
  params: {
    tagId: 'xxx'  // or placement: 'xxx'
  }
}
```

## Reference
- Prebid.org docs: https://docs.prebid.org/dev-docs/bidders/revnew.html