### PR TITLE
add gourmetads alias to msftBidAdapter

### DIFF
--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -153,8 +153,9 @@ import {
       }
 
       if (bidderParams) {
-        if (bidderParams.placement_id) {
-          extANData.placement_id = bidderParams.placement_id;
+        const placementId = bidderParams.placement_id || bidderParams.placementId;
+        if (placementId) {
+          extANData.placement_id = parseInt(placementId, 10);
         } else if (bidderParams.inv_code) {
           deepSetValue(imp, 'tagid', bidderParams.inv_code);
         }
@@ -319,14 +320,14 @@ import {
   export const spec = {
     code: BIDDER_CODE,
     gvlid: GVLID,
-    aliases: [], // TODO fill in after full transition or as seperately requested
+    aliases: ['gourmetads'], // Inherits GVLID 32 from MSFT natively
     supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
     isBidRequestValid: (bid) => {
       const params = bid.params;
       return !!(
-        (typeof params.placement_id === 'number') ||
-        (typeof params.member === 'number' && isNotEmptyString(params?.inv_code))
+        (params.placement_id || params.placementId) ||
+        (params.member && (isNotEmptyString(params?.inv_code) || isNotEmptyString(params?.invCode)))
       );
     },
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [x] Checked bidder is compatible with the current prebid version
- [x] Checked all the relvant dependencies
- [x] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
