### PR TITLE
added omnidexBidAdapter

### DIFF
--- a/modules/omnidexBidAdapter.js
+++ b/modules/omnidexBidAdapter.js
@@ -1,0 +1,54 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { getStorageManager } from '../src/storageManager.js';
+import {
+  isBidRequestValid,
+  onBidWon,
+  createUserSyncGetter,
+  createBuildRequestsFn,
+  createInterpretResponseFn, onBidBillable
+} from '../libraries/vidazooUtils/bidderUtils.js';
+
+/**
+ * @typedef {import('./omnidexBidAdapter.d.ts').OmnidexBidRequestParams} OmnidexBidRequestParams
+ */
+
+const DEFAULT_SUB_DOMAIN = 'exchange';
+const BIDDER_CODE = 'omnidex';
+const BIDDER_VERSION = '1.0.0';
+const GVLID = 1463;
+export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+
+export function createDomain(subDomain = DEFAULT_SUB_DOMAIN) {
+  return `https://${subDomain}.omni-dex.io`;
+}
+
+function createUniqueRequestData(hashUrl, bid) {
+  const { auctionId, transactionId } = bid;
+  return {
+    auctionId,
+    transactionId
+  };
+}
+
+const buildRequests = createBuildRequestsFn(createDomain, createUniqueRequestData, storage, BIDDER_CODE, BIDDER_VERSION, false);
+const interpretResponse = createInterpretResponseFn(BIDDER_CODE, false);
+const getUserSyncs = createUserSyncGetter({
+  iframeSyncUrl: 'https://sync.omni-dex.io/api/sync/iframe',
+  imageSyncUrl: 'https://sync.omni-dex.io/api/sync/image'
+});
+
+export const spec = {
+  code: BIDDER_CODE,
+  version: BIDDER_VERSION,
+  supportedMediaTypes: [BANNER, VIDEO],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs,
+  onBidWon,
+  onBidBillable,
+  gvlid: GVLID,
+};
+
+registerBidder(spec);

--- a/modules/omnidexBidAdapter.md
+++ b/modules/omnidexBidAdapter.md
@@ -1,0 +1,36 @@
+# Overview
+
+**Module Name:** Omnidex Bidder Adapter
+
+**Module Type:** Bidder Adapter
+
+**Maintainer:** dev@vidazoo.com
+
+# Description
+
+Module that connects to Omnidex's demand sources.
+
+# Test Parameters
+
+```js
+var adUnits = [
+    {
+        code: 'test-ad',
+        sizes: [[300, 250]],
+        bids: [
+            {
+                bidder: 'omnidex',
+                params: {
+                    cId: '562524b21b1c1f08117fc7f9',
+                    pId: '59ac17c192832d0011283fe3',
+                    bidFloor: 0.0001,
+                    ext: {
+                        param1: 'loremipsum',
+                        param2: 'dolorsitamet'
+                    }
+                }
+            }
+        ]
+    }
+];
+```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Bidder Integration
- [x] Checked bidder is compatible with the current prebid version
- [x] Checked all the relvant dependencies
- [x] Verified compatibility for adpushup.js
- [ ] Verified compatibility for AMP DVC
- [ ] Raise PR for Prebid submodule update in adpushup.js and AMP DVC

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
sample params

PID (Client side only) 25cv68n329154k1909176mw4
CID - Display 6a206db889e2e92ef99d63fe
CID - Video 6a206dd989e2e92ef99d6405
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
